### PR TITLE
sugar: use macros.stamp when available

### DIFF
--- a/criterion/sugar.nim
+++ b/criterion/sugar.nim
@@ -1,4 +1,4 @@
-import macros
+import macros except quote, stamp
 import sequtils
 import strutils
 import streams
@@ -14,6 +14,14 @@ import jsonExporter
 
 const
   ELLIPSIZE_THRESHOLD = 15
+
+when declared(macros.stamp):
+  template quote(body: untyped): untyped =
+    ## Shim for nimskull's quote
+    macros.stamp(body)
+else:
+  template quote(body: untyped): untyped =
+    macros.quote(body)
 
 type
   Ellipsical = (object or tuple or array or seq)


### PR DESCRIPTION
NimSkull changed `macros.quote` into a proper quasi-quoting operator, as such features like automatic binding or automatic gensym are no longer available. These features are now provided as part of the `stamp` macro.

As such, use `macros.stamp` if it's available instead of quote via a simple shim.